### PR TITLE
Hide ap ikey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+APIkey.js

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     </section>
 
     <script type="text/javascript" src="./scripts/whiteSpaceFunc.js"></script>
+    <script type="text/javascript" src="./scripts/APIkey.js"></script>
     <script type="text/javascript" src="./scripts/APIcalls.js"></script>
     <script type="text/javascript" src="./scripts/dom.js"></script>
 </body>

--- a/scripts/APIcalls.js
+++ b/scripts/APIcalls.js
@@ -1,7 +1,6 @@
 function getGifs() {
   const xhr = new XMLHttpRequest();
 
-  let APIkeyGiphy = "aGajB4I8jDTbIEhwTl7NGhvANZO8iSwQ";
   let qGiphy = searchQueries[1];
   let limitGiphy = 3;
 


### PR DESCRIPTION
- removed API key from APIcalls.js
- created a new file APIkey.js for the Giphy API key, and added this file to .gitignore
![hide](https://media3.giphy.com/media/l1J9QKk9iSUbuGt1u/giphy.gif?cid=3640f6095c93cb085a4f4b5159e55ed9)
HASHTAG HIDDEN (you will need to get the API key from me)
- added <script> to .html file
- you should have API key file in ./scripts/APIkey.js